### PR TITLE
Support column search on relation date fields by display format

### DIFF
--- a/tests/Feature/ResponseTest.php
+++ b/tests/Feature/ResponseTest.php
@@ -164,6 +164,18 @@ class ResponseTest extends FeatureTestCase
         $this->assertEquals($this->user->id, $response->getData(true)['data'][0]['id']);
     }
 
+    public function testRelationDateColumnSearch()
+    {
+        foreach (['15/06/1995', '15-06-1995'] as $searchValue) {
+            $request_data = $this->getRequestDataSample();
+            $request_data['columns'][5]['search']['value'] = $searchValue;
+            $response = $this->get('/'.$this->route_prefix.'/User?'.http_build_query($request_data));
+            $response->assertStatus(200);
+            $response->assertJsonCount(1, 'data');
+            $this->assertEquals($this->user->id, $response->getData(true)['data'][0]['id']);
+        }
+    }
+
     public function testSearchByHasOneColumn()
     {
         foreach (['Papakitsos', 'papakitsos_george@yahoo.gr'] as $searchTerm) {

--- a/tests/FeatureTestCase.php
+++ b/tests/FeatureTestCase.php
@@ -21,7 +21,7 @@ class FeatureTestCase extends TestCase
         $this->loadMigrationsFrom(__DIR__.'/database/migrations');
 
         User::factory()->has(UserLogin::factory()->count(rand(1, 5)))->count(49)->create();
-        $this->country = Country::factory()->create();
+        $this->country = Country::factory()->create(['founded_at' => '1995-06-15']);
         $this->user = User::factory()->has(UserLogin::factory()->count(rand(10, 20)))->create([
             'name' => 'George Papakitsos',
             'email' => 'papakitsos_george@yahoo.gr',
@@ -57,8 +57,10 @@ class FeatureTestCase extends TestCase
             ],
             'filters' => [
                 'date_format' => 'd/m/Y',
+                'date_display_format' => 'd/m/Y',
                 'date_delimiter' => '-dateDelimiter-',
                 'null_delimiter' => '-nullDelimiter-',
+                'date_columns' => ['founded_at'],
             ],
         ]);
     }

--- a/tests/Models/Country.php
+++ b/tests/Models/Country.php
@@ -17,6 +17,12 @@ class Country extends Model
      */
     public $timestamps = false;
 
+    protected $fillable = ['name', 'founded_at'];
+
+    protected $casts = [
+        'founded_at' => 'date',
+    ];
+
     /**
      * Create a new factory instance for the model.
      *

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -84,7 +84,7 @@ class User extends Model
     public function getRelationFields()
     {
         return [
-            'country' => ['name'],
+            'country' => ['name', 'founded_at'],
             'userLogins' => [],
             'userNameAndEmail' => ['name', 'email'],
         ];

--- a/tests/database/factories/CountryFactory.php
+++ b/tests/database/factories/CountryFactory.php
@@ -23,6 +23,7 @@ class CountryFactory extends Factory
     {
         return [
             'name' => $this->faker->country(),
+            'founded_at' => null,
         ];
     }
 }

--- a/tests/database/migrations/2014_10_12_000003_add_founded_at_to_countries_table.php
+++ b/tests/database/migrations/2014_10_12_000003_add_founded_at_to_countries_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFoundedAtToCountriesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('countries', function (Blueprint $table) {
+            $table->date('founded_at')->nullable()->after('name');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('countries', function (Blueprint $table) {
+            $table->dropColumn('founded_at');
+        });
+    }
+}


### PR DESCRIPTION
# Relation date column search by display format

Column search on relation date fields to use the display format (e.g. d/m/Y) so filtering matches what users see. 
Add `date_display_format` and `date_columns` to config:

```php
'filters' => [
    'date_format' => 'Y-m-d',
    'date_display_format' => 'd/m/Y',
    'date_delimiter' => '-dateDelimiter-',
    'null_delimiter' => '-nullDelimiter-',
    'date_columns' => ['revision_date'],
],
```

`date_columns` lists the relation field names (on the related model) that are dates shown in the UI. 
Those columns can be searched with e.g. `24/01/2024` or `24-01-2024`; both `/` and `-` work.
